### PR TITLE
Hot fix for #13: CIRCLERANGE code generation error

### DIFF
--- a/engine/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/engine/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -281,6 +281,7 @@ case class InCircleRange(point: Seq[Expression],
                          target: Seq[Expression],
                          r: Literal) extends Predicate with CodegenFallback {
   require(point.length == target.length)
+  require(r.dataType.isInstanceOf[NumericType])
   override def hasSpatial: Boolean = true
 
   override def children: Seq[Expression] = point ++ target ++ Seq(r)
@@ -304,6 +305,8 @@ case class InCircleRange(point: Seq[Expression],
 case class InKNN(point: Seq[Expression],
                  target: Seq[Expression],
                  k: Literal) extends Predicate with CodegenFallback {
+  require(k.dataType.isInstanceOf[IntegralType])
+
   override def hasSpatial: Boolean = true
 
   override def children: Seq[Expression] = point ++ target ++ Seq(k)

--- a/engine/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
+++ b/engine/sql/core/src/main/scala/org/apache/spark/sql/execution/basicOperators.scala
@@ -147,7 +147,7 @@ case class Filter(condition: Expression, child: SparkPlan) extends UnaryNode {
             Subtract(Cast(point(i), DoubleType), Cast(target(i), DoubleType)))
         val ans = exps.foldLeft[Expression](null)
           { (left, right) => if (left == null) right else Add(left, right) }
-        LessThanOrEqual(ans, Multiply(r, r))
+        LessThanOrEqual(ans, Cast(Multiply(r, r), DoubleType))
     }
     applyCondition(root_rdd, new_condition, root_rdd)
   }


### PR DESCRIPTION
This PR resolves issue #13. This issue is caused by type conversion in Simba is not automatic and implicit. We need explicitly convert data types to `DoubleType` before comparison.

Besides, we also add flags for literals used in spatial predicates to make sure further data conversion will work. 